### PR TITLE
chore: community health files, release docs, fix publish trigger

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Report incorrect behavior in tagparse
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. A minimal reproduction is the fastest path to a fix.
+  - type: input
+    id: version
+    attributes:
+      label: tagparse version
+      placeholder: "2.0.1"
+    validations:
+      required: true
+  - type: input
+    id: node
+    attributes:
+      label: Node.js version
+      placeholder: "20.11.0"
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: The template source and the data/options passed to render.
+      render: ts
+      placeholder: |
+        const tpl = Template.compile("{each:{items}|<{it}>}");
+        tpl.render({ variables: { items: ["a", "b"] }, tags: builtinTags });
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected output
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual output
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues for a duplicate.
+          required: true
+        - label: I'm on a supported version (2.x).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & discussions
+    url: https://github.com/itsamziii/tagparse/discussions
+    about: Ask usage questions and discuss ideas here, not in the issue tracker.
+  - name: Security vulnerability
+    url: https://github.com/itsamziii/tagparse/security/advisories/new
+    about: Report security issues privately — please don't open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest a new tag, API, or capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that tagparse can't do today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: API sketch or example template/output you'd expect.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and discussions for this idea.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!-- Keep PRs focused on one logical change. -->
+
+## Summary
+
+<!-- What does this change and why? -->
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Docs / CI / chore
+
+## Checklist
+
+- [ ] `pnpm run ci` passes locally (typecheck + biome + tests)
+- [ ] Added/updated tests (new behavior is tested; bug fixes have a regression test)
+- [ ] Added a changeset (`pnpm changeset`) — or this is docs/CI/test-only
+- [ ] Updated docs (README / RELEASING) if behavior or the public API changed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,10 +4,6 @@ on:
         branches:
             - main
             - next
-    pull_request:
-        branches:
-            - main
-            - next
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,42 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and maintainers pledge to make participation in the
+tagparse project a welcoming, harassment-free experience for everyone, regardless
+of background or identity. We pledge to act in ways that build an open and
+respectful community.
+
+## Our standards
+
+Examples of behavior that helps the community:
+
+- Being respectful of differing opinions and experiences
+- Giving and gracefully accepting constructive feedback
+- Focusing on what is best for the project and its users
+- Showing empathy toward other community members
+
+Examples of unacceptable behavior:
+
+- Harassment of any kind, public or private
+- Personal or political attacks, insults, or derogatory comments
+- Publishing others' private information without explicit permission
+- Other conduct that is unprofessional or inappropriate in a collaborative space
+
+## Enforcement
+
+Project maintainers are responsible for clarifying these standards and may take
+appropriate action — including editing or removing contributions, or temporarily
+or permanently banning a contributor — in response to behavior they deem
+inappropriate.
+
+Instances of unacceptable behavior may be reported to the maintainers at
+**mohd.amaan1583@gmail.com**. All reports will be reviewed and investigated
+promptly and fairly, and the reporter's privacy will be respected.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
+available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to tagparse
+
+Thanks for your interest in improving tagparse. This guide covers local setup,
+the test/lint gate, and how releases are cut.
+
+By participating you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Prerequisites
+
+- **Node.js** `>=18`
+- **pnpm** (the repo pins a version via `packageManager`; enable it with `corepack enable`)
+
+## Setup
+
+```bash
+git clone https://github.com/itsamziii/tagparse.git
+cd tagparse
+pnpm install
+```
+
+## Development workflow
+
+| Command | What it does |
+| --- | --- |
+| `pnpm test` | Run the test suite once (vitest) |
+| `pnpm test:watch` | Watch mode |
+| `pnpm run typecheck` | `tsc --noEmit` |
+| `pnpm run check` | Biome lint + format, auto-fixing in place |
+| `pnpm run lint` / `pnpm run format` | Lint only / format only |
+| `pnpm run build` | Build ESM + CJS with tsup |
+| `pnpm run bench` | Run the micro-benchmarks |
+| `pnpm run ci` | The full gate: `typecheck && biome ci . && test` |
+
+Run `pnpm run ci` before opening a PR — it is exactly what CI runs.
+
+## Tests
+
+- New behavior gets a test. Bug fixes get a regression test.
+- Don't edit a test to make it pass unless the test itself is wrong — say so in the PR.
+
+## Code style
+
+- Biome is the source of truth (4-space indent, double quotes, semicolons). Run `pnpm run check`.
+- Strict TypeScript. No `any` in the public API; prefer `unknown` + narrowing.
+- Comments explain *why*, not *what*.
+
+## Commits
+
+Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`).
+Keep the subject under ~50 chars; put the *why* in the body when it isn't obvious.
+
+## Changesets
+
+Every change that affects the published package needs a changeset:
+
+```bash
+pnpm changeset
+```
+
+Pick the bump type, write a one-line summary, and commit the generated file in
+`.changeset/`. Docs/CI/test-only changes don't need one. See
+[RELEASING.md](./RELEASING.md) for the full flow.
+
+## Pull requests
+
+1. Branch off `main`.
+2. Keep the PR focused — one logical change.
+3. `pnpm run ci` is green.
+4. Add a changeset if the package changed.
+5. Fill in the PR template.
+
+`main` is the release branch; merging a changeset there opens an automated
+release PR. You never publish to npm by hand.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,62 @@
+# Releasing
+
+Releases are driven by [Changesets](https://github.com/changesets/changesets)
+and published from CI with npm trusted publishing (OIDC provenance). You never
+run `npm publish` by hand.
+
+## 1. Add a changeset with your change
+
+Any PR that affects the published package includes a changeset:
+
+```bash
+pnpm changeset
+```
+
+It asks for the bump type and a summary, then writes a markdown file in
+`.changeset/`. Commit it with your code.
+
+Bump types (semver):
+
+- **patch** — bug fix, no API change (`2.0.0 → 2.0.1`)
+- **minor** — backward-compatible feature (`2.0.0 → 2.1.0`)
+- **major** — breaking change (`2.0.0 → 3.0.0`)
+
+Docs-, CI-, and test-only changes don't need a changeset.
+
+## 2. Merge your PR into `main`
+
+When a commit carrying changesets lands on `main`, the Publish workflow runs the
+Changesets action, which opens (or updates) a **"chore: release"** PR. That PR:
+
+- bumps `version` in `package.json`,
+- writes the new section in `CHANGELOG.md`,
+- deletes the consumed changeset files.
+
+It does **not** publish yet.
+
+## 3. Merge the "chore: release" PR
+
+Merging it pushes `main` with no pending changesets. The workflow then runs
+`changeset publish`, which builds and publishes the new version to npm as
+`latest`, with provenance.
+
+```
+your PR (+changeset) ─merge→ main ─▶ "chore: release" PR ─merge→ main ─▶ npm publish
+```
+
+## Prereleases (`next`)
+
+The workflow also publishes from a `next` branch (for `next`-tagged prereleases).
+Use Changesets prerelease mode on that branch:
+
+```bash
+pnpm changeset pre enter next   # start
+# ...normal changeset + release-PR flow, versions become x.y.z-next.N...
+pnpm changeset pre exit         # stop before promoting to a stable release
+```
+
+## Notes
+
+- The version in `package.json` is owned by Changesets — don't bump it by hand.
+- A published npm version is immutable; you can't republish the same number.
+  Ship a new patch instead.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+| ------- | --------- |
+| `2.x`   | ✅ |
+| `< 2.0` | ❌ |
+
+Fixes land on the latest `2.x` line.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Use GitHub's private vulnerability reporting:
+**Security → Report a vulnerability** on the
+[repository](https://github.com/itsamziii/tagparse/security/advisories/new).
+If you can't use that, email **mohd.amaan1583@gmail.com**.
+
+Include:
+
+- affected version(s)
+- a minimal reproduction (template source + the data/options passed to `render`)
+- impact (what an attacker gains)
+
+You'll get an acknowledgement within a few days. Once a fix is ready it ships as
+a patch release and the advisory is published with credit, unless you prefer to
+stay anonymous.
+
+## Security model
+
+tagparse makes a deliberate trust split:
+
+- **Template source is trusted.** The developer chooses what string gets
+  `compile()`d. Compiling attacker-controlled template *source* is outside the
+  default threat model — there is no cap on output size, so a hostile template
+  using nested `{each}` can expand output until it exhausts memory. If you must
+  compile untrusted templates, validate them first (see `walk` / `variableNames`
+  / `tagNames`) and bound `maxDepth`.
+- **Variable values and tag arguments are untrusted.** These are the user data
+  that flows through a trusted template. The renderer never re-parses them, never
+  evaluates code, and blocks prototype-pollution paths (`__proto__`,
+  `constructor`, `prototype`) in `pathResolver`.
+
+### Output sinks are your responsibility
+
+The library emits plain strings; it does not sanitize for any sink.
+
+- **Discord:** wrap untrusted text in `{escape:...}` / `escapeDiscord()`.
+- **HTML/DOM:** escape with `escapeHtml()` before `innerHTML`, and never paste
+  rendered output into a `javascript:`/URL context without a scheme allowlist.


### PR DESCRIPTION
Repo-health pass — no package code touched, no changeset needed.

## CI
- **publish.yml**: removed the `pull_request:` trigger. The publish job ran on every PR without npm auth and red-marked unrelated PRs (e.g. #10/#11). It now runs only on push to `main`/`next`.
- Added **Dependabot** (`npm` + `github-actions`, weekly; dev-deps grouped).

## Community health
- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1)
- `CONTRIBUTING.md` — setup, the `pnpm run ci` gate, changeset + commit conventions
- `SECURITY.md` — supported versions, private reporting, and the trust model (template source trusted, variable values untrusted; escape your sinks)
- `.github/ISSUE_TEMPLATE/` bug + feature forms and config
- `.github/PULL_REQUEST_TEMPLATE.md`

## Docs
- `RELEASING.md` — the Changesets flow: add changeset, merge to main, merge the auto release PR to publish.

Contact email in CODE_OF_CONDUCT/SECURITY is the public git email — swap if you want a different one.