### PR TITLE
ci: build dist on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
             - name: Run CI script
               run: pnpm run ci
 
+            - name: Build
+              run: pnpm run build
+
             - name: Coverage
               if: matrix.node == 22
               run: pnpm run test:coverage


### PR DESCRIPTION
Adds a build step to the matrix CI job so dist and .d.ts are built on every PR. Catches TypeScript emit/declaration regressions (e.g. a major typescript bump) that pnpm run ci misses, since it only runs typecheck + biome + test and never builds. Build runs at publish time today, so a broken build would only surface during release.

Same matrix job, so check names stay build (18..24) and branch protection is unchanged. No changeset (CI-only).