### PR TITLE
fix: unblock TS6 dts build (ignoreDeprecations baseUrl)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "target": "ES2022",
+        "ignoreDeprecations": "6.0",
         "module": "NodeNext",
         "moduleResolution": "NodeNext",
         "strict": true,


### PR DESCRIPTION
Fixes the broken main build after the TypeScript 6.0 bump (#18).

TS 6.0 promotes the deprecated baseUrl option to hard error TS5101. The tsconfig has no baseUrl, but tsup injects one for the declaration bundle, so pnpm build failed while tsc --noEmit (typecheck) passed — which is how it slipped past the merge. Sets ignoreDeprecations 6.0 per TS migration guidance; tsup reads it from tsconfig.

Verified locally: build exit 0, typecheck clean, 108 tests. The CI build step (added in #23) now gates this. No changeset — build-config only, no shipped/runtime change (2.0.1 on npm was built with TS5 and is fine).