### PR TITLE
ci: group dependabot actions + auto-merge minor/patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    auto-merge:
+        runs-on: ubuntu-latest
+        # Only Dependabot PRs.
+        if: github.actor == 'dependabot[bot]'
+        steps:
+            - name: Fetch Dependabot metadata
+              id: meta
+              uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
+
+            # Auto-merge minor and patch only. Majors (e.g. typescript 5 -> 6)
+            # stay manual so a human reviews potential breakage. Required status
+            # checks (build matrix + build step) still gate the actual merge.
+            - name: Enable auto-merge for minor and patch updates
+              if: steps.meta.outputs.update-type == 'version-update:semver-minor' || steps.meta.outputs.update-type == 'version-update:semver-patch'
+              run: gh pr merge --auto --squash "$PR_URL"
+              env:
+                  PR_URL: ${{ github.event.pull_request.html_url }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reduces dependabot noise and automates the safe bumps.

- Groups all github-actions updates into a single PR (was one per action).
- Adds a Dependabot auto-merge workflow: minor and patch updates (dev deps + actions) get GitHub auto-merge enabled; majors stay manual for review. Required status checks (the build matrix) still gate the merge, so a red build never lands.
- Repo Allow auto-merge setting enabled.

No changeset (CI/config only).